### PR TITLE
Retire l'icône compte de l'entête mobile

### DIFF
--- a/compte.html
+++ b/compte.html
@@ -29,14 +29,14 @@
         <a href="contact.html" class="text-gray-700 hover:text-pink-500 transition">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="compte.html" class="text-gray-900 font-semibold">
-          <i class="fas fa-user text-xl"></i>
-          <span class="ml-1 hidden lg:inline">Mon compte</span>
-        </a>
         <a href="panier.html" class="text-gray-700 hover:text-pink-500">
           <i class="fas fa-shopping-cart text-xl"></i>
           <span class="ml-1 hidden lg:inline">Panier</span>
           <span class="cart-count">0</span>
+        </a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-900 font-semibold">
+          <i class="fas fa-user text-xl"></i>
+          <span class="ml-1 hidden lg:inline">Mon compte</span>
         </a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu">
           <i class="fas fa-bars text-xl"></i>

--- a/contact.html
+++ b/contact.html
@@ -28,14 +28,14 @@
         <a href="contact.html" class="text-gray-900 font-semibold">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500">
-          <i class="fas fa-user text-xl"></i>
-          <span class="ml-1 hidden lg:inline">Compte</span>
-        </a>
         <a href="panier.html" class="text-gray-700 hover:text-pink-500">
           <i class="fas fa-shopping-cart text-xl"></i>
           <span class="ml-1 hidden lg:inline">Panier</span>
           <span class="cart-count">0</span>
+        </a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500">
+          <i class="fas fa-user text-xl"></i>
+          <span class="ml-1 hidden lg:inline">Compte</span>
         </a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu">
           <i class="fas fa-bars text-xl"></i>

--- a/couple.html
+++ b/couple.html
@@ -47,7 +47,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>

--- a/famille.html
+++ b/famille.html
@@ -46,7 +46,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
                     <span class="ml-1 hidden lg:inline">Panier</span>
                     <span class="cart-count">0</span>
                 </a>
-                <a href="compte.html" class="text-gray-700 hover:text-pink-500">
+                <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500">
                     <i class="fas fa-user text-xl"></i>
                     <span class="ml-1 hidden lg:inline">Compte</span>
                 </a>

--- a/mariage.html
+++ b/mariage.html
@@ -47,7 +47,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>

--- a/naissance.html
+++ b/naissance.html
@@ -46,7 +46,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>

--- a/occasions-speciales.html
+++ b/occasions-speciales.html
@@ -46,7 +46,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>

--- a/personnalisation.html
+++ b/personnalisation.html
@@ -36,7 +36,7 @@
           <span class="ml-1 hidden lg:inline">Panier</span>
           <span class="cart-count">0</span>
         </a>
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500">
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500">
           <i class="fas fa-user text-xl"></i>
           <span class="ml-1 hidden lg:inline">Compte</span>
         </a>

--- a/souvenirs-eternels.html
+++ b/souvenirs-eternels.html
@@ -46,7 +46,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <a href="compte.html" class="text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
+        <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
         <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- masque l'icône "Compte" dans l'en-tête pour les vues mobiles afin de ne laisser que le panier et le menu burger
- réorganise les icônes sur les pages Contact et Compte pour conserver l'espacement

## Testing
- `npm test` *(échoue: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c48d3cddc08321b35b1224b5269baa