### PR TITLE
feat: left align mobile menu button and refresh cart icon

### DIFF
--- a/compte.html
+++ b/compte.html
@@ -15,11 +15,16 @@
   <!-- Header -->
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800">Une <span class="text-pink-500">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800">Une <span class="text-pink-500">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -30,7 +35,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500">
-          <i class="fas fa-shopping-cart text-xl"></i>
+          <i class="fas fa-bag-shopping text-xl"></i>
           <span class="ml-1 hidden lg:inline">Panier</span>
           <span class="cart-count">0</span>
         </a>
@@ -38,9 +43,6 @@
           <i class="fas fa-user text-xl"></i>
           <span class="ml-1 hidden lg:inline">Mon compte</span>
         </a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu">
-          <i class="fas fa-bars text-xl"></i>
-        </button>
       </div>
     </div>
   </header>
@@ -69,7 +71,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800">Une <span class="text-pink-500">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800">Une <span class="text-pink-500">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -29,7 +34,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500">
-          <i class="fas fa-shopping-cart text-xl"></i>
+          <i class="fas fa-bag-shopping text-xl"></i>
           <span class="ml-1 hidden lg:inline">Panier</span>
           <span class="cart-count">0</span>
         </a>
@@ -37,9 +42,6 @@
           <i class="fas fa-user text-xl"></i>
           <span class="ml-1 hidden lg:inline">Compte</span>
         </a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu">
-          <i class="fas fa-bars text-xl"></i>
-        </button>
       </div>
     </div>
   </header>
@@ -68,7 +70,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/couple.html
+++ b/couple.html
@@ -16,11 +16,16 @@
   <!-- Header (copie légère) -->
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -46,9 +51,8 @@
         <a href="contact.html" class="text-gray-700 hover:text-pink-500 transition">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
         <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>
   </header>
@@ -87,7 +91,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/famille.html
+++ b/famille.html
@@ -15,11 +15,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -45,9 +50,8 @@
         <a href="contact.html" class="text-gray-700 hover:text-pink-500 transition">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
         <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>
   </header>
@@ -85,7 +89,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -35,16 +35,21 @@
     <!-- Header -->
     <header class="bg-white header-shadow sticky top-0 z-50">
         <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-            <div class="logo min-w-0">
-                <a href="#" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-                  <img src="image/logoheider.png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-                  <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">
-                      Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span>
-                    </span>
-                  </a>
-                  
+            <div class="flex items-center gap-3 sm:gap-4">
+                <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+                <div class="logo min-w-0">
+                    <a href="#" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+                      <img src="image/logoheider.png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+                      <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">
+                          Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span>
+                        </span>
+                      </a>
+
+                </div>
             </div>
-            
+
             <nav class="hidden lg:flex space-x-8">
                 <a href="#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
                 
@@ -122,7 +127,7 @@
             
             <div class="flex items-center space-x-4">
                 <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon">
-                    <i class="fas fa-shopping-cart text-xl"></i>
+                    <i class="fas fa-bag-shopping text-xl"></i>
                     <span class="ml-1 hidden lg:inline">Panier</span>
                     <span class="cart-count">0</span>
                 </a>
@@ -130,9 +135,6 @@
                     <i class="fas fa-user text-xl"></i>
                     <span class="ml-1 hidden lg:inline">Compte</span>
                 </a>
-                <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu">
-                    <i class="fas fa-bars text-xl"></i>
-                </button>
                 
             </div>
         </div>
@@ -288,7 +290,7 @@
 
         <div class="mt-6 text-sm text-gray-500">
           <div class="flex items-center justify-between">
-            <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+            <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
             <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
           </div>
         </div>

--- a/mariage.html
+++ b/mariage.html
@@ -16,11 +16,16 @@
   <!-- Header simplified reuse -->
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -46,9 +51,8 @@
         <a href="contact.html" class="text-gray-700 hover:text-pink-500 transition">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
         <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>
   </header>
@@ -87,7 +91,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/naissance.html
+++ b/naissance.html
@@ -15,11 +15,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -45,9 +50,8 @@
         <a href="contact.html" class="text-gray-700 hover:text-pink-500 transition">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
         <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>
   </header>
@@ -85,7 +89,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/occasions-speciales.html
+++ b/occasions-speciales.html
@@ -15,11 +15,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -45,9 +50,8 @@
         <a href="contact.html" class="text-gray-700 hover:text-pink-500 transition">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
         <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>
   </header>
@@ -85,7 +89,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/panier.html
+++ b/panier.html
@@ -15,11 +15,16 @@
   <!-- Header -->
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800">Une <span class="text-pink-500">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800">Une <span class="text-pink-500">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -30,13 +35,10 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-900 font-semibold flex items-center">
-          <i class="fas fa-shopping-cart text-xl"></i>
+          <i class="fas fa-bag-shopping text-xl"></i>
           <span class="ml-2">Panier</span>
           <span class="cart-count ml-2">0</span>
         </a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu">
-          <i class="fas fa-bars text-xl"></i>
-        </button>
       </div>
     </div>
   </header>
@@ -65,7 +67,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/personnalisation.html
+++ b/personnalisation.html
@@ -15,13 +15,18 @@
   <!-- Header (links point back to index for other sections) -->
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">
-            Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span>
-          </span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">
+              Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span>
+            </span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -32,7 +37,7 @@
       </nav>
       <div class="flex items-center space-x-4">
         <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon">
-          <i class="fas fa-shopping-cart text-xl"></i>
+          <i class="fas fa-bag-shopping text-xl"></i>
           <span class="ml-1 hidden lg:inline">Panier</span>
           <span class="cart-count">0</span>
         </a>
@@ -40,9 +45,6 @@
           <i class="fas fa-user text-xl"></i>
           <span class="ml-1 hidden lg:inline">Compte</span>
         </a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu">
-          <i class="fas fa-bars text-xl"></i>
-        </button>
       </div>
     </div>
   </header>
@@ -71,7 +73,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>

--- a/produit-flamme.html
+++ b/produit-flamme.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-intemporel.html
+++ b/produit-intemporel.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-naissance-bienvenue.html
+++ b/produit-naissance-bienvenue.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-naissance-douceur.html
+++ b/produit-naissance-douceur.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-naissance-miracle.html
+++ b/produit-naissance-miracle.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-naissance-modele-1.html
+++ b/produit-naissance-modele-1.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-naissance-modele-2.html
+++ b/produit-naissance-modele-2.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-naissance-modele-3.html
+++ b/produit-naissance-modele-3.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/produit-promesse.html
+++ b/produit-promesse.html
@@ -14,11 +14,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -27,8 +32,7 @@
         <a href="index.html#avis" class="text-gray-700 hover:text-pink-500 transition">Avis</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
       </div>
     </div>
   </header>

--- a/souvenirs-eternels.html
+++ b/souvenirs-eternels.html
@@ -15,11 +15,16 @@
 <body>
   <header class="bg-white header-shadow sticky top-0 z-50">
     <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="logo min-w-0">
-        <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
-          <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
-          <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
-        </a>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <button id="mobile-menu-button" type="button" class="lg:hidden text-gray-700 p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-300" aria-label="Ouvrir le menu">
+          <i class="fas fa-bars text-2xl"></i>
+        </button>
+        <div class="logo min-w-0">
+          <a href="index.html#accueil" class="group flex items-center gap-2 sm:gap-3 min-w-0 transition-all duration-300">
+            <img src="U (1).png" alt="Logo Une Empreinte" class="h-10 sm:h-12 w-auto shadow-sm"/>
+            <span class="font-playfair text-lg sm:text-xl font-bold text-gray-800 group-hover:text-pink-600 transition-colors duration-300 truncate max-w-[55vw] md:max-w-[60vw] lg:max-w-none">Une <span class="text-pink-500 group-hover:text-gray-800">Empreinte</span></span>
+          </a>
+        </div>
       </div>
       <nav class="hidden lg:flex space-x-8">
         <a href="index.html#accueil" class="text-gray-700 hover:text-pink-500 transition">Accueil</a>
@@ -45,9 +50,8 @@
         <a href="contact.html" class="text-gray-700 hover:text-pink-500 transition">Contact</a>
       </nav>
       <div class="flex items-center space-x-4">
-        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-shopping-cart text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
+        <a href="panier.html" class="text-gray-700 hover:text-pink-500 cart-icon"><i class="fas fa-bag-shopping text-xl"></i><span class="ml-1 hidden lg:inline">Panier</span><span class="cart-count">0</span></a>
         <a href="compte.html" class="hidden lg:flex items-center text-gray-700 hover:text-pink-500"><i class="fas fa-user text-xl"></i><span class="ml-1 hidden lg:inline">Compte</span></a>
-        <button id="mobile-menu-button" class="lg:hidden text-gray-700" aria-label="Ouvrir le menu"><i class="fas fa-bars text-xl"></i></button>
       </div>
     </div>
   </header>
@@ -85,7 +89,7 @@
     </nav>
     <div class="mt-6 text-sm text-gray-500">
       <div class="flex items-center justify-between">
-        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-shopping-cart mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
+        <a href="panier.html" class="hover:text-pink-500"><i class="fas fa-bag-shopping mr-2"></i>Panier <span class="cart-count ml-1">0</span></a>
         <a href="compte.html" class="hover:text-pink-500"><i class="fas fa-user mr-2"></i>Compte</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- repositioned the mobile menu trigger to the left of the header logo across the site for a consistent layout on small screens.
- refreshed the shopping cart icon to the sleeker bag variant in headers and mobile menus for a more polished look.

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1080c04408329b50d8e1c48591c76