### PR TITLE
Adoucir la section hero avec une tonalité plus lumineuse

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -79,7 +79,14 @@
 .font-playfair {
     font-family: 'Playfair Display', serif;
   }
-  
+
+
+/* Hero background refinements */
+.hero-video {
+    filter: brightness(1.15) saturate(1.08) contrast(1.03);
+    transform: scale(1.01);
+}
+
   
 /* Make buttons and cards rounder */
 /* Target Tailwind utility usage and native buttons */

--- a/index.html
+++ b/index.html
@@ -301,14 +301,15 @@
     <!-- Hero Section (full-bleed video with overlay text) -->
     <section id="accueil" class="relative h-[60vh] md:h-[70vh] lg:h-[80vh]">
         <!-- Full video background -->
-        <video class="absolute inset-0 w-full h-full object-cover"
+        <video class="absolute inset-0 w-full h-full object-cover hero-video"
                autoplay muted loop playsinline preload="metadata" poster="empreinte.jpeg">
             <source src="empreintevideo.mp4" type="video/mp4">
             Votre navigateur ne supporte pas la lecture vidéo.
         </video>
 
         <!-- Gradient overlay for readability -->
-        <div class="absolute inset-0 bg-gradient-to-t from-black/30 via-black/15 to-transparent"></div>
+        <div class="absolute inset-0 bg-gradient-to-t from-black/20 via-black/10 to-transparent"></div>
+        <div class="absolute inset-0 pointer-events-none bg-gradient-to-br from-[#f9e3c5]/45 via-[#f6d8b8]/30 to-transparent"></div>
 
         <!-- Text content overlay -->
         <div class="relative z-10 h-full">


### PR DESCRIPTION
## Summary
- éclaircir la vidéo d’arrière-plan du hero et ajuster l’overlay sombre pour gagner en luminosité
- ajouter un voile doré doux afin d’harmoniser la section avec l’identité visuelle
- appliquer un filtre dédié dans la feuille de styles pour rehausser la chaleur et la saturation du visuel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d24732bb548329ae2c604606151737