### PR TITLE
Restore original header appearance

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -212,19 +212,6 @@ a[class*="px-"][class*="py-"][class*="rounded"],
     border-bottom: 1px solid rgba(223,198,176,0.35); /* subtle warm hairline */
 }
 
-header.header-shadow {
-    background-color: rgba(255, 255, 255, 0.92);
-    backdrop-filter: saturate(160%) blur(16px);
-    -webkit-backdrop-filter: saturate(160%) blur(16px);
-    transition: background-color 0.3s ease, backdrop-filter 0.3s ease;
-}
-
-@supports not (backdrop-filter: blur(0)) {
-    header.header-shadow {
-        background-color: #fdf8f3; /* soft fallback when blur is unavailable */
-    }
-}
-
 /* Align the hamburger toggle completely against the left edge */
 #mobile-menu-button {
     display: inline-flex;
@@ -237,19 +224,6 @@ header.header-shadow {
 @media (min-width: 1024px) {
     #mobile-menu-button {
         display: inline-flex !important; /* override lg:hidden from Tailwind */
-    }
-}
-
-/* Ensure transparent background for header logo image */
-header .logo img {
-    background: transparent !important;
-    height: clamp(3.25rem, 10vw, 3.75rem) !important;
-    width: auto;
-}
-
-@media (min-width: 768px) {
-    header .logo img {
-        height: clamp(3.5rem, 6vw, 4rem) !important;
     }
 }
 
@@ -343,16 +317,6 @@ img[src*="logoheider.png"] {
       justify-content: center;
     }
   }
-}
-
-.cart-icon i {
-    color: var(--accent-gold-600) !important;
-    transition: color 0.25s ease;
-}
-
-.cart-icon:hover i,
-.cart-icon:focus i {
-    color: var(--accent-gold-500) !important;
 }
 
 /* Brand color system: replace Tailwind pink-* with nude shades */


### PR DESCRIPTION
## Summary
- remove the translucent header background and blur so the original solid styling returns
- drop the custom logo sizing overrides to let the default dimensions apply
- remove the gold cart icon color to restore the original header palette

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d259b0d7808329a6ed84e54322b206