### PR TITLE
Refresh mobile hero and add curated intro sections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -91,24 +91,250 @@
     text-wrap: balance;
 }
 
-.hero-primary-btn {
-    background-color: rgba(212, 175, 55, 0.72);
-    border: 1px solid rgba(212, 175, 55, 0.85);
-    color: rgba(255, 255, 255, 0.95) !important;
-    backdrop-filter: blur(4px);
-    transition: background-color 200ms ease, border-color 200ms ease, box-shadow 200ms ease;
-}
-
-.hero-primary-btn:hover {
-    background-color: rgba(224, 199, 90, 0.82);
-    border-color: rgba(224, 199, 90, 0.9);
-    color: #ffffff !important;
-}
-
 /* Hero background refinements */
 .hero-video {
     filter: brightness(1.15) saturate(1.08) contrast(1.03);
     transform: scale(1.01);
+}
+
+.hero-mobile-image {
+    filter: brightness(0.95) saturate(1.08);
+    transform: scale(1.03);
+    object-position: center top;
+}
+
+.hero-overlay-desktop {
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.18) 60%, rgba(0, 0, 0, 0.05) 100%);
+    pointer-events: none;
+}
+
+.hero-overlay-mobile {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.58) 0%, rgba(255, 255, 255, 0.28) 55%, rgba(255, 255, 255, 0.05) 100%);
+    mix-blend-mode: screen;
+    pointer-events: none;
+}
+
+.hero-warm-glow {
+    background: linear-gradient(135deg, rgba(249, 227, 197, 0.55), rgba(246, 216, 184, 0.32) 60%, rgba(255, 255, 255, 0));
+    pointer-events: none;
+}
+
+.hero-content {
+    padding-top: clamp(3rem, 15vw, 4.5rem);
+    padding-bottom: clamp(3rem, 18vw, 5.5rem);
+}
+
+.hero-lede {
+    font-size: clamp(1.02rem, 0.9vw + 1rem, 1.35rem);
+    line-height: 1.6;
+    text-wrap: balance;
+    max-width: 36rem;
+}
+
+.hero-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 3.25rem;
+    border-radius: 9999px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    padding: 0.9rem 1.75rem;
+    text-decoration: none;
+    transition: transform 200ms ease, box-shadow 200ms ease, background-color 200ms ease, border-color 200ms ease;
+}
+
+.hero-cta:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--accent-gold-500) 55%, transparent);
+    outline-offset: 2px;
+}
+
+.hero-cta-primary {
+    background: linear-gradient(135deg, rgba(212, 175, 55, 0.92), rgba(212, 175, 55, 0.78));
+    border: 1px solid rgba(212, 175, 55, 0.88);
+    color: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 14px 28px rgba(185, 170, 105, 0.28);
+}
+
+.hero-cta-primary:hover {
+    background: linear-gradient(135deg, rgba(224, 199, 90, 0.95), rgba(212, 175, 55, 0.82));
+    border-color: rgba(224, 199, 90, 0.9);
+    transform: translateY(-1px);
+}
+
+.hero-cta-outline {
+    background: rgba(255, 255, 255, 0.06);
+    border: 2px solid rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(6px);
+}
+
+.hero-cta-outline:hover {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.95);
+    transform: translateY(-1px);
+}
+
+.hero-seal {
+    position: absolute;
+    bottom: clamp(1.5rem, 6vw, 2.75rem);
+    right: clamp(1rem, 6vw, 2.75rem);
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.1));
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.18);
+    backdrop-filter: blur(8px);
+}
+
+.hero-seal-icon {
+    width: 28px;
+    height: 28px;
+    opacity: 0.75;
+}
+
+.hero-seal-text {
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--accent-gold-500);
+    white-space: nowrap;
+}
+
+@media (min-width: 640px) {
+    .hero-cta {
+        width: auto;
+    }
+}
+
+@media (min-width: 768px) {
+    .hero-content {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}
+
+@media (max-width: 767px) {
+    .hero-section {
+        min-height: min(100vh, 680px);
+    }
+
+    .hero-lede {
+        font-size: 1.05rem;
+    }
+}
+
+.favorite-card {
+    flex: 0 0 clamp(240px, 68vw, 280px);
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.72));
+    border-radius: 1.5rem;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--brand-200) 55%, transparent);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.12);
+    backdrop-filter: blur(8px);
+}
+
+.favorite-media {
+    position: relative;
+    aspect-ratio: 4 / 5;
+    overflow: hidden;
+}
+
+.favorite-media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.favorite-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.25rem 1.35rem 1.5rem;
+}
+
+.favorite-title {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #2d2a26;
+}
+
+.favorite-text {
+    font-size: 0.95rem;
+    color: #5f5146;
+    line-height: 1.5;
+}
+
+.favorite-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 3rem;
+    border-radius: 9999px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    background: linear-gradient(135deg, var(--accent-gold-500), color-mix(in srgb, var(--accent-gold-600) 88%, white 12%));
+    color: white;
+    border: 1px solid color-mix(in srgb, var(--accent-gold-600) 75%, transparent);
+    box-shadow: 0 12px 24px rgba(185, 170, 105, 0.28);
+    transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
+}
+
+.favorite-cta:hover {
+    filter: brightness(1.05);
+    transform: translateY(-1px);
+}
+
+.favorite-cta:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--accent-gold-500) 55%, transparent);
+    outline-offset: 2px;
+}
+
+.mobile-reason-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1.25rem 1.4rem;
+    border-radius: 1.5rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.72));
+    border: 1px solid color-mix(in srgb, var(--brand-200) 55%, transparent);
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.08);
+}
+
+.mobile-reason-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, var(--brand-100), var(--brand-300));
+    color: var(--accent-gold-600);
+    font-size: 1.25rem;
+    box-shadow: 0 10px 18px color-mix(in srgb, var(--brand-400) 24%, transparent);
+}
+
+.mobile-reason-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #2d2a26;
+    margin-bottom: 0.25rem;
+}
+
+.mobile-reason-text {
+    font-size: 0.95rem;
+    color: #5f5146;
+    line-height: 1.55;
 }
 
   

--- a/index.html
+++ b/index.html
@@ -298,41 +298,154 @@
     <!-- Backdrop for mobile menu -->
     <div id="mobile-backdrop" class="fixed inset-0 bg-black/40 hidden z-40" aria-hidden="true"></div>
 
-    <!-- Hero Section (full-bleed video with overlay text) -->
-    <section id="accueil" class="relative h-[60vh] md:h-[70vh] lg:h-[80vh]">
-        <!-- Full video background -->
-        <video class="absolute inset-0 w-full h-full object-cover hero-video"
-               autoplay muted loop playsinline preload="metadata" poster="empreinte.jpeg">
-            <source src="empreintevideo.mp4" type="video/mp4">
-            Votre navigateur ne supporte pas la lecture vidéo.
-        </video>
+    <!-- Hero Section (video desktop / image mobile) -->
+    <section id="accueil" class="relative hero-section h-[60vh] md:h-[70vh] lg:h-[80vh] overflow-hidden">
+        <div class="absolute inset-0">
+            <video class="hidden md:block w-full h-full object-cover hero-video"
+                   autoplay muted loop playsinline preload="metadata" poster="empreinte.jpeg">
+                <source src="empreintevideo.mp4" type="video/mp4">
+                Votre navigateur ne supporte pas la lecture vidéo.
+            </video>
+            <img src="empreinte.jpeg"
+                 alt="Cadre Une Empreinte mis en scène dans un intérieur chaleureux"
+                 class="hero-mobile-image md:hidden w-full h-full object-cover"
+                 loading="eager" fetchpriority="high">
+        </div>
 
-        <!-- Gradient overlay for readability -->
-        <div class="absolute inset-0 bg-gradient-to-t from-black/20 via-black/10 to-transparent"></div>
-        <div class="absolute inset-0 pointer-events-none bg-gradient-to-br from-[#f9e3c5]/45 via-[#f6d8b8]/30 to-transparent"></div>
+        <!-- Overlays -->
+        <div class="absolute inset-0 hero-overlay-desktop hidden md:block" aria-hidden="true"></div>
+        <div class="absolute inset-0 hero-overlay-mobile md:hidden" aria-hidden="true"></div>
+        <div class="absolute inset-0 hero-warm-glow" aria-hidden="true"></div>
 
         <!-- Text content overlay -->
         <div class="relative z-10 h-full">
-            <div class="container mx-auto h-full px-4 flex items-center">
-                <div class="max-w-2xl text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.35)]">
+            <div class="container mx-auto h-full px-4 flex items-end md:items-center">
+                <div class="hero-content max-w-xl text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.35)]">
                     <h1 class="hero-title text-white/95">
                         Immortalisez vos premiers instants avec élégance
                     </h1>
-                    <div class="mt-6 flex flex-col sm:flex-row gap-3">
-                        <a href="#produits" class="hero-primary-btn text-white font-semibold py-3 px-6 rounded-full shadow-md transition-all duration-300 ease-out transform hover:shadow-lg hover:-translate-y-0.5 text-center w-full sm:w-auto">
+                    <p class="hero-lede text-white/90 mt-4">
+                        Parce que chaque instant mérite de devenir un souvenir éternel.
+                    </p>
+                    <div class="hero-cta-group mt-6 flex flex-col sm:flex-row gap-3">
+                        <a href="#produits" class="hero-cta hero-cta-primary" aria-label="Découvrir nos créations Une Empreinte">
                             Découvrir nos créations
                         </a>
-                        <a href="personnalisation.html#personnalisation" class="border-2 border-white text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 ease-out transform hover:bg-white/10 hover:shadow-lg hover:-translate-y-0.5 text-center w-full sm:w-auto">
+                        <a href="personnalisation.html#personnalisation" class="hero-cta hero-cta-outline" aria-label="Personnaliser un cadre Une Empreinte">
                             Personnaliser un cadre
                         </a>
                     </div>
                 </div>
             </div>
         </div>
+
+        <div class="hero-seal md:hidden" role="img" aria-label="Sceau Qualité Une Empreinte">
+            <img src="image/logo-ue.svg" alt="" aria-hidden="true" class="hero-seal-icon">
+            <span class="hero-seal-text">Qualité Une Empreinte</span>
+        </div>
+    </section>
+
+    <!-- Mobile carousel -->
+    <section class="md:hidden bg-white py-12" aria-labelledby="mobile-favorites-title">
+        <div class="container mx-auto px-4">
+            <h2 id="mobile-favorites-title" class="title-font text-2xl font-semibold text-gray-900 text-center">
+                Nos créations les plus appréciées
+            </h2>
+            <p class="mt-3 text-sm text-gray-600 text-center">
+                Des cadres prêts à offrir, plébiscités par nos familles.
+            </p>
+        </div>
+        <div class="mt-6 -mx-4">
+            <ul class="flex gap-4 overflow-x-auto px-4 pb-2 hide-scrollbar" role="list" aria-label="Carrousel des créations Une Empreinte">
+                <li class="favorite-card">
+                    <div class="favorite-media">
+                        <img src="image2.jpeg" alt="Cadre naissance Une Empreinte" loading="lazy" class="w-full h-full object-cover">
+                    </div>
+                    <div class="favorite-body">
+                        <h3 class="favorite-title">Cadre naissance Douceur</h3>
+                        <p class="favorite-text">Personnalisez prénom, date et empreintes pour un souvenir tendre.</p>
+                        <a href="produit-naissance-douceur.html" class="favorite-cta" aria-label="Voir le cadre naissance Douceur">
+                            Découvrir
+                        </a>
+                    </div>
+                </li>
+                <li class="favorite-card">
+                    <div class="favorite-media">
+                        <img src="image1.jpeg" alt="Cadre couple Une Empreinte" loading="lazy" class="w-full h-full object-cover">
+                    </div>
+                    <div class="favorite-body">
+                        <h3 class="favorite-title">Cadre Intemporel</h3>
+                        <p class="favorite-text">Un cadre raffiné pour célébrer vos moments à deux ou en famille.</p>
+                        <a href="produit-intemporel.html" class="favorite-cta" aria-label="Voir le cadre Intemporel">
+                            Découvrir
+                        </a>
+                    </div>
+                </li>
+                <li class="favorite-card">
+                    <div class="favorite-media">
+                        <img src="image3.jpeg" alt="Cadre empreintes Une Empreinte" loading="lazy" class="w-full h-full object-cover">
+                    </div>
+                    <div class="favorite-body">
+                        <h3 class="favorite-title">Cadre Promesse</h3>
+                        <p class="favorite-text">Capturez vos vœux avec un design doré et une finition premium.</p>
+                        <a href="produit-promesse.html" class="favorite-cta" aria-label="Voir le cadre Promesse">
+                            Découvrir
+                        </a>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </section>
+
+    <!-- Mobile "Pourquoi choisir" cards -->
+    <section class="md:hidden bg-pink-50 py-12" aria-labelledby="mobile-why-title">
+        <div class="container mx-auto px-4">
+            <h2 id="mobile-why-title" class="title-font text-2xl font-semibold text-gray-900 text-center">
+                Pourquoi choisir Une Empreinte ?
+            </h2>
+            <div class="mt-8 space-y-4">
+                <article class="mobile-reason-card">
+                    <div class="mobile-reason-icon" aria-hidden="true">
+                        <i class="fas fa-wand-magic-sparkles"></i>
+                    </div>
+                    <div>
+                        <h3 class="mobile-reason-title">Créations sur-mesure</h3>
+                        <p class="mobile-reason-text">Chaque cadre est pensé avec vous pour refléter vos émotions et votre histoire.</p>
+                    </div>
+                </article>
+                <article class="mobile-reason-card">
+                    <div class="mobile-reason-icon" aria-hidden="true">
+                        <i class="fas fa-gem"></i>
+                    </div>
+                    <div>
+                        <h3 class="mobile-reason-title">Finitions premium</h3>
+                        <p class="mobile-reason-text">Papier texturé, encres résistantes et cadres nobles pour durer.</p>
+                    </div>
+                </article>
+                <article class="mobile-reason-card">
+                    <div class="mobile-reason-icon" aria-hidden="true">
+                        <i class="fas fa-truck"></i>
+                    </div>
+                    <div>
+                        <h3 class="mobile-reason-title">Expédition soignée</h3>
+                        <p class="mobile-reason-text">Livraison rapide et emballage protecteur pour un cadeau impeccable.</p>
+                    </div>
+                </article>
+                <article class="mobile-reason-card">
+                    <div class="mobile-reason-icon" aria-hidden="true">
+                        <i class="fas fa-heart"></i>
+                    </div>
+                    <div>
+                        <h3 class="mobile-reason-title">Accompagnement dédié</h3>
+                        <p class="mobile-reason-text">Une équipe à votre écoute pour personnaliser chaque détail sereinement.</p>
+                    </div>
+                </article>
+            </div>
+        </div>
     </section>
 
     <!-- Brand Logo between hero and features -->
-    <section class="pt-2 pb-0 md:pt-3 md:pb-1">
+    <section class="pt-2 pb-0 md:pt-3 md:pb-1 hidden md:block">
         <div class="container mx-auto px-4 text-center">
             <img src="logook.jpeg" alt="Logo Une Empreinte" class="mx-auto h-44 sm:h-48 md:h-56 lg:h-64 w-auto object-contain">
         </div>
@@ -342,7 +455,7 @@
     
 
     <!-- Features Section -->
-    <section class="pt-2 md:pt-3 lg:pt-4 pb-16 bg-white">
+    <section class="pt-2 md:pt-3 lg:pt-4 pb-16 bg-white hidden md:block">
         <div class="container mx-auto px-4">
             <div class="relative text-center mb-10 md:mb-12">
                 <!-- Bulle décorative -->


### PR DESCRIPTION
## Summary
- replace the mobile hero with a photo-based layout that keeps the desktop video intact and adds premium copy, CTAs, and a quality seal
- introduce mobile-only sections for the favourites carousel and the “Pourquoi choisir Une Empreinte ?” reassurance cards
- extend the stylesheet with responsive hero, carousel, and card styles tailored for touch targets and accessibility

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d65faee89c8329b34a951e0c43c933