### PR TITLE
Add mobile hover animations for hero CTAs

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -105,6 +105,35 @@
     color: #ffffff !important;
 }
 
+@media (max-width: 640px) {
+  .hero-cta {
+    transition: transform 200ms ease, box-shadow 200ms ease;
+    will-change: transform, box-shadow;
+  }
+
+  .hero-cta:hover {
+    transform: scale(1.02);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  }
+
+  .hero-cta:active {
+    transform: scale(0.98);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  }
+}
+
+@media (max-width: 640px) and (prefers-reduced-motion: reduce) {
+  .hero-cta {
+    transition: none !important;
+  }
+
+  .hero-cta:hover,
+  .hero-cta:active {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+}
+
 /* Hero background refinements */
 .hero-video {
     filter: brightness(1.15) saturate(1.08) contrast(1.03);

--- a/index.html
+++ b/index.html
@@ -319,10 +319,10 @@
                         Immortalisez vos premiers instants avec élégance
                     </h1>
                     <div class="mt-6 flex flex-col sm:flex-row gap-3">
-                        <a href="#produits" class="block w-full text-center rounded-full px-5 py-3 border border-white/85 text-white font-medium bg-transparent backdrop-blur-[2px] hover:bg-white/10 active:scale-[0.98] transition">
+                        <a href="#produits" class="hero-cta hero-cta--discover block w-full text-center rounded-full px-5 py-3 border border-white/85 text-white font-medium bg-transparent backdrop-blur-[2px] hover:bg-white/10 active:scale-[0.98] transition">
                             Découvrir nos créations
                         </a>
-                        <a href="personnalisation.html#personnalisation" class="border-2 border-white text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 ease-out transform hover:bg-white/10 hover:shadow-lg hover:-translate-y-0.5 text-center w-full sm:w-auto">
+                        <a href="personnalisation.html#personnalisation" class="hero-cta hero-cta--personalize border-2 border-white text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 ease-out transform hover:bg-white/10 hover:shadow-lg hover:-translate-y-0.5 text-center w-full sm:w-auto">
                             Personnaliser un cadre
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
- scope the two hero call-to-action links with dedicated classes
- add mobile-only hover and active animations with a reduced-motion fallback

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8fa62a8388329840ebc536298e6fc