### PR TITLE
Adjust mobile menu behavior

### DIFF
--- a/compte.html
+++ b/compte.html
@@ -48,7 +48,7 @@
   </header>
 
   <!-- Mobile Menu (outside header) -->
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/contact.html
+++ b/contact.html
@@ -47,7 +47,7 @@
   </header>
 
   <!-- Mobile Menu (outside header) -->
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/couple.html
+++ b/couple.html
@@ -58,7 +58,7 @@
   </header>
 
   <!-- Mobile Menu -->
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,15 +1,15 @@
 .mobile-menu {
-    transform: translateX(100%);
+    transform: translateX(-100%);
     transition: transform 0.3s ease-in-out;
     visibility: hidden;
     opacity: 0;
     pointer-events: none;
     z-index: 1000; /* keep above decorative overlays */
     width: min(88vw, 360px);
-    border-left: 1px solid var(--brand-200);
+    border-right: 1px solid var(--brand-200);
     background: linear-gradient(180deg, #ffffff 0%, color-mix(in srgb, var(--brand-50) 85%, #fff) 100%);
-    border-top-left-radius: 16px;
-    border-bottom-left-radius: 16px;
+    border-top-right-radius: 16px;
+    border-bottom-right-radius: 16px;
 }
 
 .mobile-menu.open {
@@ -266,7 +266,7 @@ a[class*="px-"][class*="py-"][class*="rounded"],
 
 @media (min-width: 1024px) {
     #mobile-menu-button {
-        display: inline-flex !important; /* override lg:hidden from Tailwind */
+        display: none !important;
     }
 }
 

--- a/famille.html
+++ b/famille.html
@@ -56,7 +56,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
 </header>
 
     <!-- Mobile Menu (outside header to avoid stacking/transform issues) -->
-    <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+    <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
         <div class="mnav-header flex items-center justify-between mb-3">
             <div class="flex items-center gap-2">
                 <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/mariage.html
+++ b/mariage.html
@@ -58,7 +58,7 @@
   </header>
 
   <!-- Mobile Menu -->
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/naissance.html
+++ b/naissance.html
@@ -56,7 +56,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/occasions-speciales.html
+++ b/occasions-speciales.html
@@ -56,7 +56,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/panier.html
+++ b/panier.html
@@ -44,7 +44,7 @@
   </header>
 
   <!-- Mobile Menu (outside header) -->
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/personnalisation.html
+++ b/personnalisation.html
@@ -50,7 +50,7 @@
   </header>
 
   <!-- Mobile Menu (outside header) -->
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-flamme.html
+++ b/produit-flamme.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-intemporel.html
+++ b/produit-intemporel.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-naissance-bienvenue.html
+++ b/produit-naissance-bienvenue.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-naissance-douceur.html
+++ b/produit-naissance-douceur.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-naissance-miracle.html
+++ b/produit-naissance-miracle.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-naissance-modele-1.html
+++ b/produit-naissance-modele-1.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-naissance-modele-2.html
+++ b/produit-naissance-modele-2.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-naissance-modele-3.html
+++ b/produit-naissance-modele-3.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/produit-promesse.html
+++ b/produit-promesse.html
@@ -37,7 +37,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>

--- a/souvenirs-eternels.html
+++ b/souvenirs-eternels.html
@@ -56,7 +56,7 @@
     </div>
   </header>
 
-  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 right-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
+  <div id="mobile-menu" class="mobile-menu fixed inset-y-0 left-0 bg-white shadow-lg z-50 p-4 overflow-y-auto">
     <div class="mnav-header flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <img src="U (1).png" alt="Logo" class="w-8 h-8 rounded-md"/>


### PR DESCRIPTION
## Summary
- make the mobile drawer slide in from the left edge across all pages
- hide the hamburger toggle on desktop viewports so it only appears on mobile and tablet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8fc8ec4688329a47cee1cc4e69677